### PR TITLE
Aggregate ECS crash-loop Slack alerts with DynamoDB-backed dedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@ lambda/**/*.zip
 lambda/__pycache__/
 lambda/*.pyc
 
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+venv/
+*.egg-info/
+
 # IDE
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ module "ecs_monitor" {
 | [aws_cloudwatch_log_group.ecs_events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_resource_policy.crash_events_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
 | [aws_cloudwatch_log_resource_policy.ecs_events_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
+| [aws_dynamodb_table.crash_alert_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_dynamodb_table.logs_anomalies_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_lambda_permission.allow_eventbridge_crash_notifier](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.allow_eventbridge_daily_summary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
@@ -228,6 +229,8 @@ module "ecs_monitor" {
 | <a name="input_coralogix_account"></a> [coralogix\_account](#input\_coralogix\_account) | Coralogix account name for generating UI links | `string` | `""` | no |
 | <a name="input_coralogix_api_key"></a> [coralogix\_api\_key](#input\_coralogix\_api\_key) | Coralogix API key for log retrieval | `string` | `""` | no |
 | <a name="input_coralogix_region"></a> [coralogix\_region](#input\_coralogix\_region) | Coralogix region (e.g., us, eu, eu2, ap, ap2) | `string` | `""` | no |
+| <a name="input_crash_alert_aggregation_window_minutes"></a> [crash\_alert\_aggregation\_window\_minutes](#input\_crash\_alert\_aggregation\_window\_minutes) | Sliding window in minutes used to aggregate repeat crashes of the same service into a single Slack parent message | `number` | `30` | no |
+| <a name="input_crash_alert_mode"></a> [crash\_alert\_mode](#input\_crash\_alert\_mode) | How to surface repeat crashes within the aggregation window: 'edit' updates the parent only, 'thread' posts thread replies only, 'edit\_and\_thread' does both | `string` | `"edit_and_thread"` | no |
 | <a name="input_crash_notifier_function_name"></a> [crash\_notifier\_function\_name](#input\_crash\_notifier\_function\_name) | Name of the Lambda function for crash notifications | `string` | `""` | no |
 | <a name="input_crash_notifier_slack_channel"></a> [crash\_notifier\_slack\_channel](#input\_crash\_notifier\_slack\_channel) | Slack channel ID or name for sending crash notifications | `string` | `""` | no |
 | <a name="input_daily_summary_function_name"></a> [daily\_summary\_function\_name](#input\_daily\_summary\_function\_name) | Name of the Lambda function for daily crash summaries | `string` | `""` | no |
@@ -265,6 +268,8 @@ module "ecs_monitor" {
 
 | Name | Description |
 |------|-------------|
+| <a name="output_crash_alert_state_table_arn"></a> [crash\_alert\_state\_table\_arn](#output\_crash\_alert\_state\_table\_arn) | ARN of the DynamoDB table used to aggregate crash-loop alerts (if enabled) |
+| <a name="output_crash_alert_state_table_name"></a> [crash\_alert\_state\_table\_name](#output\_crash\_alert\_state\_table\_name) | Name of the DynamoDB table used to aggregate crash-loop alerts (if enabled) |
 | <a name="output_crash_notifier_lambda_arn"></a> [crash\_notifier\_lambda\_arn](#output\_crash\_notifier\_lambda\_arn) | ARN of the crash notifier Lambda function (if enabled) |
 | <a name="output_crash_notifier_lambda_name"></a> [crash\_notifier\_lambda\_name](#output\_crash\_notifier\_lambda\_name) | Name of the crash notifier Lambda function (if enabled) |
 | <a name="output_daily_summary_lambda_arn"></a> [daily\_summary\_lambda\_arn](#output\_daily\_summary\_lambda\_arn) | ARN of the daily summary Lambda function (if enabled) |

--- a/lambda/crash_notifier/alert_state.py
+++ b/lambda/crash_notifier/alert_state.py
@@ -1,0 +1,160 @@
+"""
+DynamoDB-backed aggregation state for ECS crash alerts.
+
+Opens a sliding window per service on the first crash and records repeat crashes
+against that window using atomic conditional writes so concurrent Lambda
+invocations (EventBridge scales wide) can't race each other.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+dynamodb = boto3.resource("dynamodb")
+
+RECENT_CRASHES_CAP = 10
+
+
+def _table():
+    table_name = os.environ["ALERT_STATE_TABLE"]
+    return dynamodb.Table(table_name)
+
+
+def _now_epoch() -> int:
+    return int(datetime.now(timezone.utc).timestamp())
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def service_key(cluster: str, service: str, region: str) -> str:
+    return f"{cluster}#{service}#{region}"
+
+
+def _crash_entry(crash: Dict[str, Any]) -> str:
+    """Serialize a crash into a compact JSON string for the recent_crashes list."""
+    task_arn = crash.get("task_arn") or ""
+    task_id = task_arn.split("/")[-1] if task_arn else "unknown"
+    return json.dumps(
+        {
+            "task_id": task_id,
+            "container_failures": crash.get("container_reason")
+            or crash.get("stopped_reason")
+            or "",
+            "exit_code": crash.get("exit_code"),
+            "ts": _now_iso(),
+        }
+    )
+
+
+def get_or_create_alert_state(
+    key: str, current_crash: Dict[str, Any], window_seconds: int
+) -> Dict[str, Any]:
+    """
+    Open a new window or record a repeat crash against the live window.
+
+    Returns:
+        {"new": True,  "item": {...}}  — new window opened; caller must post parent.
+        {"new": False, "item": {...}}  — live window; caller should edit/thread-reply.
+    """
+    table = _table()
+    now = _now_epoch()
+    now_iso = _now_iso()
+    expires_at = now + window_seconds
+    entry = _crash_entry(current_crash)
+
+    try:
+        resp = table.update_item(
+            Key={"service_key": key},
+            UpdateExpression=(
+                "SET crash_count = :one, "
+                "first_crash_ts = :now_iso, "
+                "last_crash_ts = :now_iso, "
+                "window_expires_at = :expires, "
+                "recent_crashes = :entry_list "
+                "REMOVE slack_message_ts, slack_channel_id"
+            ),
+            ConditionExpression=(
+                "attribute_not_exists(service_key) OR window_expires_at < :now"
+            ),
+            ExpressionAttributeValues={
+                ":one": 1,
+                ":now": now,
+                ":now_iso": now_iso,
+                ":expires": expires_at,
+                ":entry_list": [entry],
+            },
+            ReturnValues="ALL_NEW",
+        )
+        return {"new": True, "item": resp["Attributes"]}
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "ConditionalCheckFailedException":
+            raise
+
+    # Live window exists — increment.
+    resp = table.update_item(
+        Key={"service_key": key},
+        UpdateExpression=(
+            "ADD crash_count :one "
+            "SET last_crash_ts = :now_iso, "
+            "window_expires_at = :expires, "
+            "recent_crashes = list_append("
+            "if_not_exists(recent_crashes, :empty), :entry_list)"
+        ),
+        ExpressionAttributeValues={
+            ":one": 1,
+            ":now_iso": now_iso,
+            ":expires": expires_at,
+            ":entry_list": [entry],
+            ":empty": [],
+        },
+        ReturnValues="ALL_NEW",
+    )
+    item = resp["Attributes"]
+
+    # Cap recent_crashes at RECENT_CRASHES_CAP (keep the most recent).
+    recent = item.get("recent_crashes") or []
+    if len(recent) > RECENT_CRASHES_CAP:
+        trimmed = recent[-RECENT_CRASHES_CAP:]
+        table.update_item(
+            Key={"service_key": key},
+            UpdateExpression="SET recent_crashes = :trimmed",
+            ExpressionAttributeValues={":trimmed": trimmed},
+        )
+        item["recent_crashes"] = trimmed
+
+    return {"new": False, "item": item}
+
+
+def finalize_new_message_ts(key: str, channel: str, ts: str) -> bool:
+    """
+    Record the Slack ts of a freshly posted parent message.
+
+    Returns True on success, False if another invocation beat us to it (caller
+    should delete their duplicate Slack message).
+    """
+    table = _table()
+    try:
+        table.update_item(
+            Key={"service_key": key},
+            UpdateExpression="SET slack_message_ts = :ts, slack_channel_id = :ch",
+            ConditionExpression="attribute_not_exists(slack_message_ts)",
+            ExpressionAttributeValues={":ts": ts, ":ch": channel},
+        )
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def get_existing_state(key: str) -> Optional[Dict[str, Any]]:
+    """Read the current state item (used when handling a repeat crash)."""
+    resp = _table().get_item(Key={"service_key": key}, ConsistentRead=True)
+    return resp.get("Item")

--- a/lambda/crash_notifier/crash_notifier.py
+++ b/lambda/crash_notifier/crash_notifier.py
@@ -6,48 +6,111 @@ This module orchestrates the workflow using specialized utility modules.
 """
 
 import json
+import os
 from typing import Dict, Any
 
-# Import our utility modules
 from slack_notifier import SlackNotifier
 from ecs_utils import extract_crash_info, enrich_crash_data
+from alert_state import (
+    service_key,
+    get_or_create_alert_state,
+    finalize_new_message_ts,
+)
+
+
+DEFAULT_WINDOW_MINUTES = 30
+VALID_MODES = ("edit", "thread", "edit_and_thread")
+
+
+def _window_seconds() -> int:
+    try:
+        minutes = int(os.environ.get("AGGREGATION_WINDOW_MINUTES", DEFAULT_WINDOW_MINUTES))
+    except ValueError:
+        minutes = DEFAULT_WINDOW_MINUTES
+    return max(1, minutes) * 60
+
+
+def _alert_mode() -> str:
+    mode = os.environ.get("CRASH_ALERT_MODE", "edit_and_thread")
+    return mode if mode in VALID_MODES else "edit_and_thread"
+
+
+def _build_thread_reply_text(crash_info: Dict[str, Any], crash_count: int) -> str:
+    task_arn = crash_info.get("task_arn") or ""
+    task_id = task_arn.split("/")[-1] if task_arn else "unknown"
+    reason = crash_info.get("container_reason") or crash_info.get("stopped_reason") or "unknown"
+    exit_code = crash_info.get("exit_code")
+    exit_str = f"exit {exit_code}" if exit_code is not None else "launch failure"
+    return f"Repeat crash #{crash_count}: Task `{task_id}` — {exit_str} — {reason}"
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    """
-    Process ECS crash events and send enriched notifications to Slack
-    """
+    """Process ECS crash events and send enriched, deduplicated notifications to Slack."""
     try:
-        # Extract event details
-        detail = event.get('detail', {})
+        detail = event.get("detail", {})
         crash_info = extract_crash_info(detail)
-        
-        # Enrich with additional data
-        enriched_info = enrich_crash_data(crash_info)
-        
-        # Send to Slack using bot API
-        slack_notifier = SlackNotifier()
-        success = slack_notifier.send_crash_notification(enriched_info)
-        
-        if success:
-            print("Crash notification sent successfully via Slack bot")
-        else:
-            print("Failed to send crash notification via Slack bot")
-        
-        return {
-            'statusCode': 200,
-            'body': json.dumps({
-                'message': 'Crash notification processed successfully',
-                'taskArn': crash_info.get('task_arn'),
-                'slackNotificationSent': success
-            })
-        }
-        
+        enriched = enrich_crash_data(crash_info)
+
+        cluster_arn = enriched.get("cluster_arn", "") or ""
+        region = cluster_arn.split(":")[3] if cluster_arn.count(":") >= 3 else os.environ.get("AWS_REGION", "us-east-1")
+        key = service_key(enriched["cluster_name"], enriched["service_name"], region)
+
+        state = get_or_create_alert_state(key, enriched, _window_seconds())
+        notifier = SlackNotifier()
+
+        if state["new"]:
+            ok, channel, ts = notifier.post_new_alert(enriched, aggregation=state["item"])
+            if not ok or not ts or not channel:
+                print("❌ Failed to post new parent alert or capture ts")
+                return _response(200, enriched, slack_ok=ok, action="new_post_failed")
+
+            won = finalize_new_message_ts(key, channel, ts)
+            if not won:
+                print("⚠️  Lost ts-write race — deleting duplicate Slack message")
+                notifier.delete_message(channel, ts)
+                return _response(200, enriched, slack_ok=True, action="race_lost_deleted")
+
+            return _response(200, enriched, slack_ok=True, action="new_parent_posted")
+
+        item = state["item"]
+        channel = item.get("slack_channel_id")
+        ts = item.get("slack_message_ts")
+        crash_count = int(item.get("crash_count", 1))
+
+        if not channel or not ts:
+            # Previous invocation opened the window but hasn't finalized the ts yet.
+            # Post a thread-less reply is not possible; skip silently to avoid dup parents.
+            print("⚠️  Live window has no slack_message_ts yet — skipping this repeat")
+            return _response(200, enriched, slack_ok=False, action="skipped_pending_parent")
+
+        mode = _alert_mode()
+        did_anything = False
+
+        if mode in ("edit", "edit_and_thread"):
+            blocks = notifier._create_crash_blocks(enriched, aggregation=item)
+            text = f"🚨 ECS Crash Loop: {enriched['service_name']} (x{crash_count})"
+            did_anything = notifier.update_alert(channel, ts, blocks, text) or did_anything
+
+        if mode in ("thread", "edit_and_thread"):
+            reply_text = _build_thread_reply_text(enriched, crash_count)
+            did_anything = notifier.reply_in_thread(channel, ts, reply_text) or did_anything
+
+        return _response(200, enriched, slack_ok=did_anything, action=f"aggregated_{mode}")
+
     except Exception as e:
-        print(f"Error processing crash event: {str(e)}")
-        return {
-            'statusCode': 500,
-            'body': json.dumps({
-                'error': str(e)
-            })
-        }
+        print(f"Error processing crash event: {e}")
+        return {"statusCode": 500, "body": json.dumps({"error": str(e)})}
+
+
+def _response(status: int, crash_info: Dict[str, Any], slack_ok: bool, action: str) -> Dict[str, Any]:
+    return {
+        "statusCode": status,
+        "body": json.dumps(
+            {
+                "message": "Crash notification processed",
+                "taskArn": crash_info.get("task_arn"),
+                "slackNotificationSent": slack_ok,
+                "action": action,
+            }
+        ),
+    }

--- a/lambda/crash_notifier/requirements-dev.txt
+++ b/lambda/crash_notifier/requirements-dev.txt
@@ -1,0 +1,3 @@
+boto3>=1.34.0
+moto[dynamodb]>=5.0.0
+requests>=2.25.0

--- a/lambda/crash_notifier/slack_notifier.py
+++ b/lambda/crash_notifier/slack_notifier.py
@@ -53,29 +53,88 @@ class SlackNotifier:
             return False, None
     
     def send_crash_notification(self, crash_info: Dict[str, Any]) -> bool:
-        """Send crash notification with logs as attachment."""
-        
+        """Send crash notification with logs as attachment. Legacy single-shot path."""
+        ok, _channel, _ts = self.post_new_alert(crash_info)
+        return ok
+
+    def post_new_alert(
+        self,
+        crash_info: Dict[str, Any],
+        blocks: Optional[list] = None,
+        aggregation: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[bool, Optional[str], Optional[str]]:
+        """
+        Post a fresh parent alert. Uses the file-upload flow when logs are attached.
+
+        Returns (ok, channel_id, message_ts).
+        """
         if not self.bot_token or not self.channel:
             print("❌ SLACK_BOT_TOKEN and SLACK_CHANNEL must be configured for Slack notifications.")
-            return False
-        
-        # Create blocks for the message
-        blocks = self._create_crash_blocks(crash_info)
-        
-        # If we have logs, send with attachment
+            return False, None, None
+
+        if blocks is None:
+            blocks = self._create_crash_blocks(crash_info, aggregation=aggregation)
+
         if crash_info.get('recent_logs'):
-            return self._send_message_with_file(blocks, crash_info)
-        else:
-            # Send just the message without attachment
-            payload = {
-                "blocks": blocks,
-                "text": f"🚨 Task Crash: {crash_info['service_name']} in {crash_info['cluster_name']}"  # Fallback text for notifications
-            }
-            success, _ = self._send_message(payload, "Crash notification")
-            return success
+            ok, ts = self._send_message_with_file(blocks, crash_info)
+            return ok, (self.channel if ok else None), ts
+
+        payload = {
+            "blocks": blocks,
+            "text": f"🚨 Task Crash: {crash_info['service_name']} in {crash_info['cluster_name']}",
+        }
+        ok, ts = self._send_message(payload, "Crash notification")
+        return ok, (self.channel if ok else None), ts
+
+    def update_alert(self, channel: str, ts: str, blocks: list, text: str) -> bool:
+        """Edit a previously posted parent alert via chat.update."""
+        if not self.bot_token:
+            print("❌ SLACK_BOT_TOKEN not configured. Cannot update Slack message.")
+            return False
+        payload = {"channel": channel, "ts": ts, "blocks": blocks, "text": text}
+        return self._slack_api_call("chat.update", payload, "Crash alert edit")
+
+    def reply_in_thread(self, channel: str, thread_ts: str, text: str) -> bool:
+        """Post a thread reply under a parent alert."""
+        if not self.bot_token:
+            print("❌ SLACK_BOT_TOKEN not configured. Cannot post thread reply.")
+            return False
+        payload = {"channel": channel, "thread_ts": thread_ts, "text": text}
+        return self._slack_api_call("chat.postMessage", payload, "Crash alert thread reply")
+
+    def delete_message(self, channel: str, ts: str) -> bool:
+        """Delete a Slack message (used when losing a ts-write race)."""
+        if not self.bot_token:
+            return False
+        payload = {"channel": channel, "ts": ts}
+        return self._slack_api_call("chat.delete", payload, "Crash alert delete")
+
+    def _slack_api_call(self, method: str, payload: Dict, message_type: str) -> bool:
+        """Minimal Slack Web API wrapper for JSON methods other than the main post path."""
+        url = f"https://slack.com/api/{method}"
+        headers = {
+            "Authorization": f"Bearer {self.bot_token}",
+            "Content-Type": "application/json",
+        }
+        try:
+            response = requests.post(url, headers=headers, json=payload, timeout=30)
+            response.raise_for_status()
+            result = response.json()
+            if result.get("ok"):
+                print(f"✅ {message_type} succeeded")
+                return True
+            print(f"❌ {message_type} failed: {result.get('error', 'Unknown error')}")
+            return False
+        except Exception as e:
+            print(f"❌ {message_type} raised: {e}")
+            return False
     
-    def _create_crash_blocks(self, crash_info: Dict[str, Any]) -> list:
-        """Create Slack blocks for crash notification."""
+    def _create_crash_blocks(self, crash_info: Dict[str, Any], aggregation: Optional[Dict[str, Any]] = None) -> list:
+        """Create Slack blocks for crash notification.
+
+        When aggregation is provided and has crash_count > 1, the header gets an
+        (xN) suffix and an aggregation section is added.
+        """
         # Format started time
         started_at = crash_info.get('started_at', '')
         formatted_started_time = 'N/A'
@@ -85,17 +144,25 @@ class SlackNotifier:
                 formatted_started_time = started_time.strftime('%Y-%m-%d %H:%M:%S UTC')
             except Exception:
                 formatted_started_time = started_at
-        
+
         # Create AWS console link for the service
         aws_region = crash_info.get('cluster_arn', '').split(':')[3] if crash_info.get('cluster_arn') else 'us-east-1'
         service_url = f"https://{aws_region}.console.aws.amazon.com/ecs/v2/clusters/{crash_info['cluster_name']}/services/{crash_info['service_name']}/health"
-        
+
+        crash_count = int(aggregation.get('crash_count', 1)) if aggregation else 1
+        count_suffix = f" (x{crash_count})" if crash_count > 1 else ""
+        header_text = (
+            f"🚨 ECS Crash Loop Detected: {crash_info['service_name']} ({crash_info['cluster_name']}){count_suffix}"
+            if crash_count > 1
+            else f"🚨 Task Crash Detected: {crash_info['service_name']} ({crash_info['cluster_name']})"
+        )
+
         blocks = [
             {
                 "type": "header",
                 "text": {
                     "type": "plain_text",
-                    "text": f"🚨 Task Crash Detected: {crash_info['service_name']} ({crash_info['cluster_name']})",
+                    "text": header_text,
                     "emoji": True
                 }
             },
@@ -127,6 +194,21 @@ class SlackNotifier:
                 }
             }
         ]
+
+        if aggregation and crash_count > 1:
+            first_seen = aggregation.get('first_crash_ts', '')
+            last_update = aggregation.get('last_crash_ts', '')
+            blocks.append({
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*Repeats:* x{crash_count}\n"
+                        f"*First seen:* {first_seen}\n"
+                        f"*Last update:* {last_update}"
+                    ),
+                },
+            })
         
         # Add task ARN for debugging
         task_id = crash_info['task_arn'].split('/')[-1] if crash_info['task_arn'] else 'unknown'
@@ -191,11 +273,11 @@ class SlackNotifier:
             
         return reason_text
     
-    def _send_message_with_file(self, blocks: list, crash_info: Dict[str, Any]) -> bool:
+    def _send_message_with_file(self, blocks: list, crash_info: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
         """Send a single message with both blocks and file attachment using modern Slack API."""
         if not self.bot_token or not self.channel:
             print("❌ Cannot send message with file without SLACK_BOT_TOKEN and SLACK_CHANNEL")
-            return False
+            return False, None
         
         service_name = crash_info.get('service_name', 'unknown')
         task_id = crash_info['task_arn'].split('/')[-1] if crash_info['task_arn'] else 'unknown'
@@ -226,14 +308,14 @@ class SlackNotifier:
             
             if not upload_url_result.get("ok"):
                 print(f"❌ Failed to get upload URL: {upload_url_result.get('error', 'Unknown error')}")
-                return False
-            
+                return False, None
+
             upload_url = upload_url_result.get("upload_url")
             file_id = upload_url_result.get("file_id")
-            
+
             if not upload_url or not file_id:
                 print("❌ Missing upload_url or file_id in response")
-                return False
+                return False, None
             
             # Step 2: Upload file to the URL
             upload_response = requests.post(upload_url, files={'file': (filename, file_content, 'text/plain')}, timeout=30)
@@ -264,14 +346,26 @@ class SlackNotifier:
             
             if complete_result.get("ok"):
                 print(f"✅ Sent crash notification with blocks and attached log file: {filename}")
-                return True
+                files = complete_result.get("files") or []
+                ts = None
+                if files:
+                    shares = (files[0].get("shares") or {})
+                    for scope in ("public", "private"):
+                        for _ch_id, entries in (shares.get(scope) or {}).items():
+                            if entries:
+                                ts = entries[0].get("ts")
+                                if ts:
+                                    break
+                        if ts:
+                            break
+                return True, ts
             else:
                 print(f"❌ Failed to complete file upload {filename}: {complete_result.get('error', 'Unknown error')}")
-                return False
-                
+                return False, None
+
         except Exception as e:
             print(f"❌ Failed to send message with file {filename}: {e}")
-            return False
+            return False, None
     
     def _create_log_file_content(self, crash_info: Dict[str, Any]) -> str:
         """Create the log file content for the crash."""

--- a/lambda/crash_notifier/tests/test_crash_notifier.py
+++ b/lambda/crash_notifier/tests/test_crash_notifier.py
@@ -1,0 +1,306 @@
+"""
+Tests for the crash_notifier aggregation/deduplication logic.
+
+Run from lambda/crash_notifier/ with:
+    python -m unittest tests.test_crash_notifier -v
+"""
+
+import importlib
+import json
+import os
+import sys
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import boto3
+from moto import mock_aws
+
+
+# Ensure the parent lambda directory is importable (flat-module layout).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_LAMBDA_DIR = os.path.dirname(_HERE)
+if _LAMBDA_DIR not in sys.path:
+    sys.path.insert(0, _LAMBDA_DIR)
+
+
+TABLE_NAME = "test-crash-alert-state"
+TEST_CHANNEL = "C_TEST"
+
+
+def _base_env():
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_REGION"] = "us-east-1"
+    os.environ["ALERT_STATE_TABLE"] = TABLE_NAME
+    os.environ["AGGREGATION_WINDOW_MINUTES"] = "30"
+    os.environ["CRASH_ALERT_MODE"] = "edit_and_thread"
+    os.environ["SLACK_BOT_TOKEN"] = "xoxb-test"
+    os.environ["SLACK_CHANNEL"] = TEST_CHANNEL
+    os.environ["CLUSTER_NAME"] = "test-cluster"
+
+
+def _sample_event(task_id="t1", exit_code=1, reason="oom"):
+    return {
+        "detail": {
+            "clusterArn": "arn:aws:ecs:us-east-1:123456789012:cluster/test-cluster",
+            "group": "service:my-service",
+            "taskArn": f"arn:aws:ecs:us-east-1:123456789012:task/test-cluster/{task_id}",
+            "taskDefinitionArn": "arn:aws:ecs:us-east-1:123456789012:task-definition/my-service:42",
+            "startedAt": "2026-04-23T10:00:00Z",
+            "createdAt": "2026-04-23T10:00:00Z",
+            "stoppedReason": reason,
+            "stopCode": "EssentialContainerExited",
+            "lastStatus": "STOPPED",
+            "desiredStatus": "STOPPED",
+            "containers": [
+                {"name": "app", "exitCode": exit_code, "reason": reason},
+            ],
+        }
+    }
+
+
+class FakeSlackResponse:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+class FakeSlack:
+    """
+    Minimal stand-in for requests.post that routes Slack API calls and records them.
+
+    Each call captures (url, payload). Default behavior:
+    - chat.postMessage  -> assigns an incrementing ts (returns {"ok": True, "channel": C, "ts": ts})
+    - chat.update       -> returns {"ok": True} and records the update
+    - chat.delete       -> returns {"ok": True}
+    """
+
+    def __init__(self):
+        self.calls = []
+        self._ts_counter = 1_700_000_000
+        # Optional override: map of URL-substring -> FakeSlackResponse
+
+    def __call__(self, url, headers=None, json=None, data=None, files=None, timeout=None):
+        self.calls.append({"url": url, "json": json, "data": data, "files": bool(files)})
+        if url.endswith("/api/chat.postMessage"):
+            self._ts_counter += 1
+            ts = f"{self._ts_counter}.000100"
+            return FakeSlackResponse({"ok": True, "channel": TEST_CHANNEL, "ts": ts})
+        if url.endswith("/api/chat.update"):
+            return FakeSlackResponse({"ok": True, "channel": json["channel"], "ts": json["ts"]})
+        if url.endswith("/api/chat.delete"):
+            return FakeSlackResponse({"ok": True})
+        return FakeSlackResponse({"ok": False, "error": f"unhandled:{url}"}, status=200)
+
+
+def _posts(fake: FakeSlack):
+    return [c for c in fake.calls if c["url"].endswith("/api/chat.postMessage")]
+
+
+def _updates(fake: FakeSlack):
+    return [c for c in fake.calls if c["url"].endswith("/api/chat.update")]
+
+
+def _deletes(fake: FakeSlack):
+    return [c for c in fake.calls if c["url"].endswith("/api/chat.delete")]
+
+
+@mock_aws
+class CrashNotifierAggregationTests(unittest.TestCase):
+    def setUp(self):
+        _base_env()
+        # Create DynamoDB table under moto.
+        ddb = boto3.client("dynamodb", region_name="us-east-1")
+        ddb.create_table(
+            TableName=TABLE_NAME,
+            KeySchema=[{"AttributeName": "service_key", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "service_key", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+
+        # Fresh module imports under moto context.
+        for mod in ("crash_notifier", "alert_state", "slack_notifier", "ecs_utils", "logs_utils"):
+            if mod in sys.modules:
+                del sys.modules[mod]
+        import alert_state  # noqa: E402
+        import slack_notifier  # noqa: E402
+        import crash_notifier  # noqa: E402
+
+        self.alert_state = alert_state
+        self.slack_notifier = slack_notifier
+        self.crash_notifier = crash_notifier
+
+        # Stub enrich_crash_data to skip real ECS/log calls.
+        self.enrich_patcher = patch.object(
+            crash_notifier,
+            "enrich_crash_data",
+            side_effect=lambda info: {**info, "recent_logs": []},
+        )
+        self.enrich_patcher.start()
+
+        self.fake = FakeSlack()
+        self.requests_patcher = patch("slack_notifier.requests.post", side_effect=self.fake)
+        self.requests_patcher.start()
+
+    def tearDown(self):
+        self.enrich_patcher.stop()
+        self.requests_patcher.stop()
+
+    def _get_state(self, cluster="test-cluster", service="my-service", region="us-east-1"):
+        key = self.alert_state.service_key(cluster, service, region)
+        return self.alert_state.get_existing_state(key)
+
+    # ---- 1. First crash opens a window, posts parent, writes ts ----
+    def test_first_crash_opens_window(self):
+        self.crash_notifier.lambda_handler(_sample_event("t1"), None)
+
+        posts = _posts(self.fake)
+        self.assertEqual(len(posts), 1, "should post exactly one parent message")
+        self.assertEqual(len(_updates(self.fake)), 0)
+        self.assertEqual(len(_deletes(self.fake)), 0)
+
+        item = self._get_state()
+        self.assertIsNotNone(item)
+        self.assertEqual(int(item["crash_count"]), 1)
+        self.assertEqual(item["slack_channel_id"], TEST_CHANNEL)
+        self.assertTrue(item["slack_message_ts"])  # ts recorded
+
+    # ---- 2. Second crash within window -> 1 edit + 1 thread reply, x2 header ----
+    def test_second_crash_edits_and_threads(self):
+        self.crash_notifier.lambda_handler(_sample_event("t1"), None)
+        first_ts = self._get_state()["slack_message_ts"]
+
+        self.crash_notifier.lambda_handler(_sample_event("t2"), None)
+
+        posts = _posts(self.fake)
+        updates = _updates(self.fake)
+        self.assertEqual(len(posts), 2, "parent + thread reply = 2 postMessage calls")
+        self.assertEqual(len(updates), 1, "exactly one chat.update for the edit")
+
+        # The edit preserves the original ts.
+        self.assertEqual(updates[0]["json"]["ts"], first_ts)
+        # The header text carries "(x2)".
+        header_block = updates[0]["json"]["blocks"][0]
+        self.assertIn("x2", header_block["text"]["text"])
+
+        # The second postMessage is a thread reply on the parent ts.
+        thread_reply = posts[1]["json"]
+        self.assertEqual(thread_reply["thread_ts"], first_ts)
+
+        item = self._get_state()
+        self.assertEqual(int(item["crash_count"]), 2)
+
+    # ---- 3. 'edit' mode skips thread reply ----
+    def test_edit_mode_skips_thread(self):
+        os.environ["CRASH_ALERT_MODE"] = "edit"
+        # Re-import crash_notifier so _alert_mode picks up new env at call time (already reads env fresh each call).
+        self.crash_notifier.lambda_handler(_sample_event("t1"), None)
+        self.crash_notifier.lambda_handler(_sample_event("t2"), None)
+
+        # 1 parent post, 0 thread replies, 1 edit
+        self.assertEqual(len(_posts(self.fake)), 1)
+        self.assertEqual(len(_updates(self.fake)), 1)
+
+    # ---- 4. 'thread' mode skips edit ----
+    def test_thread_mode_skips_edit(self):
+        os.environ["CRASH_ALERT_MODE"] = "thread"
+        self.crash_notifier.lambda_handler(_sample_event("t1"), None)
+        self.crash_notifier.lambda_handler(_sample_event("t2"), None)
+
+        # 1 parent post + 1 thread reply = 2 posts, 0 updates
+        self.assertEqual(len(_posts(self.fake)), 2)
+        self.assertEqual(len(_updates(self.fake)), 0)
+        self.assertEqual(_posts(self.fake)[1]["json"].get("thread_ts"),
+                         _posts(self.fake)[0]["json"].get("ts") or self._find_first_parent_ts())
+
+    def _find_first_parent_ts(self):
+        # Fall back: read it from DynamoDB.
+        return self._get_state()["slack_message_ts"]
+
+    # ---- 5. Window expiry opens a fresh message ----
+    def test_window_expiry_opens_fresh_parent(self):
+        self.crash_notifier.lambda_handler(_sample_event("t1"), None)
+        first_ts = self._get_state()["slack_message_ts"]
+
+        # Force expiry by writing a past window_expires_at.
+        ddb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = ddb.Table(TABLE_NAME)
+        table.update_item(
+            Key={"service_key": self.alert_state.service_key("test-cluster", "my-service", "us-east-1")},
+            UpdateExpression="SET window_expires_at = :past",
+            ExpressionAttributeValues={":past": 1},
+        )
+
+        self.crash_notifier.lambda_handler(_sample_event("t2"), None)
+
+        posts = _posts(self.fake)
+        self.assertEqual(len(posts), 2, "expired window triggers a new parent post, not a thread reply")
+        self.assertEqual(len(_updates(self.fake)), 0)
+
+        item = self._get_state()
+        self.assertEqual(int(item["crash_count"]), 1, "new window resets crash_count")
+        self.assertNotEqual(item["slack_message_ts"], first_ts)
+
+    # ---- 6. finalize_new_message_ts race loser calls chat.delete ----
+    def test_finalize_race_loser_deletes(self):
+        # Pre-populate state as if another invocation already opened + finalized a parent.
+        key = self.alert_state.service_key("test-cluster", "my-service", "us-east-1")
+        now = int(datetime.now(timezone.utc).timestamp())
+        ddb = boto3.resource("dynamodb", region_name="us-east-1")
+        ddb.Table(TABLE_NAME).put_item(
+            Item={
+                "service_key": key,
+                "crash_count": 1,
+                "first_crash_ts": "2026-04-23T10:00:00Z",
+                "last_crash_ts": "2026-04-23T10:00:00Z",
+                "window_expires_at": now + 1800,
+                "slack_channel_id": TEST_CHANNEL,
+                "slack_message_ts": "1700000000.000999",
+                "recent_crashes": ["{}"],
+            }
+        )
+
+        # Force get_or_create to treat this as a NEW window (simulating the race
+        # where our step-1 conditional write wins concurrently with another winner):
+        # simplest way is to patch get_or_create_alert_state to return new=True despite
+        # the existing item — this is exactly the race we're simulating.
+        original = self.alert_state.get_or_create_alert_state
+
+        def fake_get_or_create(key, crash, window_seconds):
+            # Return as if we opened a fresh window (new=True), but leave the row alone
+            # so finalize's condition "attribute_not_exists(slack_message_ts)" fails.
+            return {
+                "new": True,
+                "item": {
+                    "service_key": key,
+                    "crash_count": 1,
+                    "first_crash_ts": "2026-04-23T11:00:00Z",
+                    "last_crash_ts": "2026-04-23T11:00:00Z",
+                    "window_expires_at": now + 1800,
+                    "recent_crashes": ["{}"],
+                },
+            }
+
+        with patch.object(self.crash_notifier, "get_or_create_alert_state", side_effect=fake_get_or_create):
+            self.crash_notifier.lambda_handler(_sample_event("t2"), None)
+
+        self.assertEqual(len(_posts(self.fake)), 1, "we posted once")
+        self.assertEqual(len(_deletes(self.fake)), 1, "race loser deletes its own message")
+
+        # State still has the original winner's ts, not ours.
+        item = self._get_state()
+        self.assertEqual(item["slack_message_ts"], "1700000000.000999")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/main.tf
+++ b/main.tf
@@ -139,6 +139,9 @@ module "crash_notifier_lambda" {
     ELASTICSEARCH_PASSWORD           = var.elasticsearch_password
     ELASTICSEARCH_INDEX_PATTERN      = var.elasticsearch_index_pattern
     KIBANA_URL                       = var.kibana_url
+    ALERT_STATE_TABLE                = aws_dynamodb_table.crash_alert_state[0].name
+    AGGREGATION_WINDOW_MINUTES       = tostring(var.crash_alert_aggregation_window_minutes)
+    CRASH_ALERT_MODE                 = var.crash_alert_mode
   }
 
   cloudwatch_logs_retention_in_days = var.log_retention_days
@@ -178,6 +181,18 @@ module "crash_notifier_lambda" {
         "ec2:DetachNetworkInterface"
       ],
       resources = ["*"]
+    },
+    dynamodb = {
+      effect = "Allow",
+      actions = [
+        "dynamodb:GetItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:PutItem",
+        "dynamodb:DeleteItem"
+      ],
+      resources = [
+        aws_dynamodb_table.crash_alert_state[0].arn
+      ]
     }
   }
 
@@ -187,6 +202,31 @@ module "crash_notifier_lambda" {
     Name        = var.crash_notifier_function_name != "" ? var.crash_notifier_function_name : "${var.cluster_name}-crash-notifier"
     Environment = var.environment
     Purpose     = "ECS crash event processing and Slack notifications"
+  }
+}
+
+# DynamoDB table for crash alert aggregation state (deduplicates repeat crashes within a window)
+resource "aws_dynamodb_table" "crash_alert_state" {
+  count = var.enable_crash_notifier ? 1 : 0
+
+  name         = "${var.cluster_name}-crash-alert-state"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "service_key"
+
+  attribute {
+    name = "service_key"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "window_expires_at"
+    enabled        = true
+  }
+
+  tags = {
+    Name        = "${var.cluster_name}-crash-alert-state"
+    Environment = var.environment
+    Purpose     = "Aggregate ECS crash-loop Slack alerts within a sliding window"
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,16 @@ output "crash_notifier_lambda_name" {
   value       = var.enable_crash_notifier ? module.crash_notifier_lambda[0].lambda_function_name : null
 }
 
+output "crash_alert_state_table_name" {
+  description = "Name of the DynamoDB table used to aggregate crash-loop alerts (if enabled)"
+  value       = var.enable_crash_notifier ? aws_dynamodb_table.crash_alert_state[0].name : null
+}
+
+output "crash_alert_state_table_arn" {
+  description = "ARN of the DynamoDB table used to aggregate crash-loop alerts (if enabled)"
+  value       = var.enable_crash_notifier ? aws_dynamodb_table.crash_alert_state[0].arn : null
+}
+
 output "daily_summary_lambda_arn" {
   description = "ARN of the daily summary Lambda function (if enabled)"
   value       = var.enable_daily_summary ? module.daily_summary_lambda[0].lambda_function_arn : null

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,23 @@ variable "crash_notifier_function_name" {
   default     = ""
 }
 
+variable "crash_alert_aggregation_window_minutes" {
+  description = "Sliding window in minutes used to aggregate repeat crashes of the same service into a single Slack parent message"
+  type        = number
+  default     = 30
+}
+
+variable "crash_alert_mode" {
+  description = "How to surface repeat crashes within the aggregation window: 'edit' updates the parent only, 'thread' posts thread replies only, 'edit_and_thread' does both"
+  type        = string
+  default     = "edit_and_thread"
+
+  validation {
+    condition     = contains(["edit", "thread", "edit_and_thread"], var.crash_alert_mode)
+    error_message = "crash_alert_mode must be one of: edit, thread, edit_and_thread."
+  }
+}
+
 variable "enable_coralogix_integration" {
   description = "Whether to enable Coralogix integration for log retrieval"
   type        = bool


### PR DESCRIPTION
## Summary
- Collapse repeat crashes of the same service into one aggregated Slack parent within a sliding window, backed by a new `${cluster_name}-crash-alert-state` DynamoDB table using atomic conditional writes so parallel Lambda invocations don't race.
- Within the window, repeats edit the parent (adds `(xN)` header + `*Repeats/First seen/Last update*` section) and/or post a short thread reply, configurable via new `crash_alert_mode` variable (`edit` | `thread` | `edit_and_thread`, default `edit_and_thread`); window length via `crash_alert_aggregation_window_minutes` (default 30).
- No behavior change for isolated crashes — first crash in a window posts just like before; purely additive dedup.

## Test plan
- [x] `terraform fmt -recursive` + `terraform validate` (Success, only pre-existing warnings)
- [x] `python -m unittest tests.test_crash_notifier -v` under `moto[dynamodb]` — 6/6 passing (first crash opens window; second crash edits + threads with `x2`; `edit` mode skips thread; `thread` mode skips edit; window expiry opens fresh parent; finalize race loser calls `chat.delete`)
- [ ] Live smoke: force-fail an ECS task 4x in 2min → one parent with `(x4)` header + 3 thread replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)