### PR TITLE
Enable server-side encryption for DynamoDB tables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -223,6 +223,10 @@ resource "aws_dynamodb_table" "crash_alert_state" {
     enabled        = true
   }
 
+  server_side_encryption {
+    enabled = true
+  }
+
   tags = {
     Name        = "${var.cluster_name}-crash-alert-state"
     Environment = var.environment
@@ -352,6 +356,10 @@ resource "aws_dynamodb_table" "logs_anomalies_state" {
   ttl {
     attribute_name = "ttl"
     enabled        = true
+  }
+
+  server_side_encryption {
+    enabled = true
   }
 
   tags = {


### PR DESCRIPTION
## Summary
This change enables server-side encryption for two DynamoDB tables to enhance data security at rest.

## Key Changes
- Added server-side encryption configuration to the `crash_alert_state` DynamoDB table
- Added server-side encryption configuration to the `logs_anomalies_state` DynamoDB table
- Both tables now have encryption enabled using AWS-managed keys (default behavior)

## Implementation Details
Server-side encryption is now explicitly enabled on both DynamoDB tables. This ensures that data stored in these tables is encrypted at rest, improving the security posture of the infrastructure. The configuration uses AWS DynamoDB's default encryption settings with AWS-managed keys.

https://claude.ai/code/session_01RrVPpCSMYMAKbheLuHahFf